### PR TITLE
Tweaks to Install Process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 Drivers/Tuya TS004F/TS004F.groovy.bak
 *.bak
 Drivers/Tuya Temperature Humidity Illuminance LCD Display with a Clock/new 16.txt
+.hubitat/metadata.json

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 Drivers/Tuya TS004F/TS004F.groovy.bak
 *.bak
 Drivers/Tuya Temperature Humidity Illuminance LCD Display with a Clock/new 16.txt
-.hubitat/metadata.json

--- a/Apps/Device Health Status.groovy
+++ b/Apps/Device Health Status.groovy
@@ -44,14 +44,16 @@ preferences {
 def mainPage() {
 	if(state.devices == null) state.devices = [:]
 	if(state.devicesList == null) state.devicesList = []
+	if(app.getInstallationState() == "COMPLETE") {hideDevices=true} else {hideDevices=false}
+
 	dynamicPage(name: "mainPage", title: "Device Health Status Control Table", uninstall: true, install: true) {
-		section {
-            input name: "filterHealthCheckOnly", type: "bool", title: "Filter only devices that have 'Healtch Check' capability", submitOnChange: true, defaultValue: false
+		section("Device Selection", hideable: true,hidden: hideDevices) {
+			input name: "filterHealthCheckOnly", type: "bool", title: "Filter only devices that have 'Healtch Check' capability", submitOnChange: true, defaultValue: false
 			input name:"devices", type: filterHealthCheckOnly ? "capability.healthCheck" : "capability.*", title: "Select devices w/ <b>Health Status</b> attribute", multiple: true, submitOnChange: true, width: 4
 			devices.each {dev ->
 				if(!state.devices["$dev.id"]) {
 					state.devices["$dev.id"] = [
-                        healthStatus: dev.currentValue("healthStatus"), 
+						healthStatus: dev.currentValue("healthStatus"), 
                     ]
 					state.devicesList += dev.id
 				}
@@ -63,9 +65,17 @@ def mainPage() {
 					devices.each{d ->  newState["$d.id"] = state.devices["$d.id"]}
 					state.devices = newState
 				}
+			}
+		}
+		if(hideDevices) {
+			section {
 				updated()
 				paragraph displayTable()
 				input "refresh", "button", title: "Refresh Table", width: 2
+			}
+		} else {
+			section("CLICK DONE TO INSTALL APP AFTER SELECTING DEVICES") {
+				paragraph ""
 			}
 		}
 	}


### PR DESCRIPTION
Added a few lines that I wrote as lessons learned from using the table.

1. A new app install will have the device selection section expanded. The table will not be shown. A prompt will show telling the user to finish installing the app.
2. Once the app installation is completed, the device selection section will be collapsed by default. 

I ran into some weird issues where I would create the app and forget to click "Done" to actually "install" the app instance. I would forget to click "done" because of the table being populated immediately.